### PR TITLE
fix: "no value of type int8 is greater than math.MaxInt8" eg. 127

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -146,7 +146,7 @@ func InitializeLog(console, logfile io.Writer) {
 		if log_level < 0 {
 			log_level = 0
 		}
-		if log_level > 127 {
+		if log_level > 126 {
 			log_level = 127
 		}
 		Log_Level_Console = zap.NewAtomicLevelAt(zapcore.Level(0 - log_level))


### PR DESCRIPTION
anything higher than 126 will be log_level 127,  the maximum value for an Int8