### PR TITLE
fix: use constant from time package

### DIFF
--- a/globals/globals.go
+++ b/globals/globals.go
@@ -167,7 +167,7 @@ func InitializeLog(console, logfile io.Writer) {
 	zf := zap.NewDevelopmentEncoderConfig()
 	zc := zap.NewDevelopmentEncoderConfig()
 	zc.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	zc.EncodeTime = zapcore.TimeEncoderOfLayout("02/01 15:04:05")
+	zc.EncodeTime = zapcore.TimeEncoderOfLayout(time.DateTime) // https://pkg.go.dev/time
 
 	file_encoder := zapcore.NewJSONEncoder(zf)
 	console_encoder := zapcore.NewConsoleEncoder(zc)


### PR DESCRIPTION
> "It is a regrettable historic error that the date uses the American convention of putting the numerical month before the day."
- [source](https://pkg.go.dev/time) 