### PR TITLE
fix: remove comment about non-implemented code

### DIFF
--- a/cmd/dero-wallet-cli/main.go
+++ b/cmd/dero-wallet-cli/main.go
@@ -455,16 +455,6 @@ func Create_New_Wallet(l *readline.Instance) (w *walletapi.Wallet_Disk, err erro
 		return
 	}
 
-	// a new account has been created, append the seed to user home directory
-
-	//usr, err := user.Current()
-	/*if err != nil {
-	      globals.Logger.Warnf("Cannot get current username to save recovery key and password")
-	  }else{ // we have a user, get his home dir
-
-
-	  }*/
-
 	return
 }
 


### PR DESCRIPTION
I guess it would make sense if you were running instances of DEROHE as a custodian or maybe as an earlier iteration of the web-wallet; however, in my opinion, this is no longer necessary for anything other than historical purposes.